### PR TITLE
applied changes

### DIFF
--- a/classic/game.js
+++ b/classic/game.js
@@ -60,17 +60,46 @@ Game.prototype.move = function(dir) {
       }
 
       var tile = this.grid.tiles[i][j];
-      if (condition) {
-        if (tile) {
-          if (!tile.neighbors()[dir]) {
-            newGrid.addTile(tile.value, nI, nJ);
+      
+      if (tile) { 
+        //if it is a tile it can be checked
+        
+        if (condition){
+          //var neighbor = tile.neighbors()[dir];
+          var neighbor = newGrid.tiles[nI][nJ];
+
+          if (!neighbor) { 
+            //if condition is true and the possible target isnt already a tile
+            
+            //give existing div to new tile. You never made a new one when it successfully moved.
+            newGrid.addTile(tile.value, nI, nJ, tile.div); 
             tile.updateGrid(newGrid);
             tile.moveTo(nI, nJ);
+          
+          } else if ( neighbor !== false && neighbor.value == tile.value) {
+            //checking for adding...
+            
+            neighbor.value += tile.value;
+            neighbor.div.children[0].textContent = neighbor.value; 
+            //maybe remove the whole neighbor and add a new one? 
+
+            newGrid.div.removeChild(tile.div);
+            tile = false;
+
+            //if the tile is another value, stay in place..
           }
+
+        } else {
+          //if condition is false: the target spot is outside of the grid,
+          //stay in place, otherwise it would disappear of the grid.
+          
+          newGrid.addTile(tile.value, tile.x, tile.y, tile.div);
+          tile.updateGrid(newGrid);
+          tile.moveTo(tile.x, tile.y);
         }
-      }
+      } 
     }
   }
-
+  
   this.grid = newGrid;
 }

--- a/classic/grid.js
+++ b/classic/grid.js
@@ -27,8 +27,9 @@ Grid.prototype.reset = function() {
   this.tiles = create2DArray(this.width, this.height);
 }
 
-Grid.prototype.addTile = function(value, x, y) {
-  this.tiles[x][y] = new Tile(value, this, x, y);
+Grid.prototype.addTile = function(value, x, y, div) {
+   //changed this so is uses the existing div.
+  this.tiles[x][y] = new Tile(value, this, x, y, div);
 }
 
 Grid.prototype.createElement = function() {

--- a/classic/tile.js
+++ b/classic/tile.js
@@ -1,8 +1,12 @@
-function Tile(value, grid, x, y) {
+function Tile(value, grid, x, y, div) {
   this.value = value;
   this.updateGrid(grid);
   this.x = x;
   this.y = y;
+  
+  //this is where (if a div is given) it sets it to its own, so in the .moveTo 
+  //function this.div.style can be set.
+  this.div = div;
 }
 
 Tile.prototype.updateGrid = function(grid) {
@@ -14,10 +18,12 @@ Tile.prototype.neighbors = function() {
   var tiles = this.grid.tiles;
   var i = this.x;
   var j = this.y;
+
   return [tiles[i][j-1],
-          tiles[i-1][j],
+          tiles[i-1] ? tiles[i-1][j] : false,
           tiles[i][j+1],
-          tiles[i+1][j]];
+          tiles[i+1] ? tiles[i+1][j] : false
+  ]
 }
 
 Tile.prototype.createElement = function() {


### PR DESCRIPTION
Hey Simon, 

There are a few things I changed to make this work. I've added comments in the code. Github also shows where I deleted lines (marked as red) and wrote new ones (marked as green). You can see that under the 'files changed' tab.

- First change: 
When you make the new grid, you give it the previous grid's div. That tells me you want to keep the elements (not recreate them every move), but in game.move(), where you add the tiles to the newGrid, you didn't pass through the existing tile div.
The newGrid would contain a tile without a div and when you call the tile.moveTo function, it gives an error because it calls on this.div.style.
The changes in grid.addTile() (grid.js line 32) and the constructor function of Tile (tile.js line 1 & 9) make this possible.

- Second change:
The solution I gave:
```javascript
return [
    tiles[i][j-1],
    tiles[i-1] ? tiles[i-1][j] : false,
    tiles[i][j+1],
    tiles[i+1] ? tiles[i+1][j] : false
]
```
Does work. However, it's 'useless.js' (haha). You should look up the neighbors in the newGrid! 
This piece of code in the game.move function (line 31) is the key: 

```javascript
for (var _i = 0; _i < this.grid.width; _i++) {
    for (var _j = 0; _j < this.grid.height; _j++) {
      var i = dir === 3 ? this.grid.width - 1 - _i : _i; //this part
      var j = dir === 2 ? this.grid.height - 1 - _j : _j; //this part
    }
}
```
Clever piece of code, did you think of that? :o That move the first tiles in the direction first.
Now, when you move the second piece, the first one already moved from the spot in the existing grid. That is why you have to check the new grid, not the existing one.
You could technically remove it from the existing grid, but then you would be modifying two grids, that is illogical. 

In the switch where you calculate the condition and the new I and J (grid.move line 39), you actually calculate the neighbor already!
Neighbor wouldn't be the right term, because you actually are checking the place where is tile SHOULD move to. It's more like a 'target'. So on line 69 of game.js:
```javascript
var neighbor = newGrid.tiles[nI][nJ];
```
You get your neighbor.

I've added a little bit of code that makes the tile stay in place if the condition is false (target is outside grid) and a part where you can add the logic to add the tiles together. How I did that is maybe not how you want it to happen, I'm not familiar with how the game actually works. But I think you can figure out how to make that happen.

I am showing you what I did, so you can make your own conclusion. This is the only way I think off to make myself clear.

If you have any questions please ask them :)

Greetings, 
Ivan. 

